### PR TITLE
Fixes !say tts (I believe this is what was originally intended)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DougleyBot
-[![Version](https://img.shields.io/badge/Version-1.3.4-green.svg?style=flat-square)](https://github.com/SteamingMutt/DougleyBot/releases)
+[![Version](https://img.shields.io/badge/Version-1.3.5-green.svg?style=flat-square)](https://github.com/SteamingMutt/DougleyBot/releases)
 [![Status](https://img.shields.io/badge/Status-Ready-green.svg?style=flat-square)]()
 [![Node](https://img.shields.io/badge/Node-4.2.2-blue.svg?style=flat-square)](http://nodejs.org)
 [![NPM](https://img.shields.io/badge/NPM-3.5.0-blue.svg?style=flat-square)](http://nodejs.org)

--- a/discord_bot.js
+++ b/discord_bot.js
@@ -378,7 +378,9 @@ var commands = {
     process: function(bot, msg, suffix) {
       var bot_permissions = msg.channel.permissionsOf(bot.user);
       if (suffix.search("!say") === -1) {
-        bot.sendMessage(msg.channel, suffix, true + "-" + msg.author);
+//        bot.sendMessage(msg.channel, suffix, true + "-" + msg.author);
+//        This line makes no sense... it appears there is an attempt to add "-"+msg.author to the suffix, and true is supposed to enable the boolean /tts function. This command is useless if it adds the msg.author, so I'll just fix tts for now now lol
+          bot.sendMessage(msg.channel, suffix, {tts:"true"});
         if (!msg.channel.server){return;}
         if (bot_permissions.hasPermission("manageMessages")) {
           bot.deleteMessage(msg);
@@ -387,7 +389,7 @@ var commands = {
           bot.sendMessage(msg.channel, "*This works best when I have the permission to delete messages!*");
         }
       } else {
-        bot.sendMessage(msg.channel, "HEY " + msg.sender + " STOP THAT!", true);
+        bot.sendMessage(msg.channel, "HEY " + msg.sender + " STOP THAT!", {tts:"true"});
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DougleyBot",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Bot for Discord app",
   "readme": "README.md",
   "maintainers": [],


### PR DESCRIPTION
{tts:"true"} is the proper format for adding options to client commands,
it requires an object not just a value (This is obviously for
compatability when more options are added down the line in discord.js)
See comment in-line for removal of msg.author (that wasn't working for
OBVIOUS reasons lol who added this wtf)